### PR TITLE
Allow insertion of bare CSS in <style> tag

### DIFF
--- a/src/stringify/script_data.py
+++ b/src/stringify/script_data.py
@@ -20,11 +20,12 @@ def wrap_code(code: str, conditions: Union[bool, list]):
 def stringify_script_data(sd: object, indent_size: int, in_html: bool) -> str:
     srcTag = f" src=\"{sd['src']}\"" if "src" in sd else ""
     module = ' type="module"' if sd["type"] == "esm" else ""
+    tag = 'style' if sd["type"] == 'css' else 'script'
 
     opening, closing = (
         (
-            f'<script {sd["tag"]}{module}{srcTag}>',
-            "</script>",
+            f'<{tag} {sd["tag"]}{module}{srcTag}>',
+            f'</{tag}>',
         )
         if in_html
         else (


### PR DESCRIPTION
When CSS is selected as the type in the Javascript tab, insert it in a `<style>` tag rather than a `<script>` tag.

This approach works well for allowing Anki Asset Manager to manage CSS as long as the insertion target is `template`.